### PR TITLE
feat: add H key for vim-style navigation up

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This will replace glyphs with simple, text-based indicators (`[DIR]/`, `..`) tha
 | ↑ / ↓          | Move selection up or down    |
 | `J` / `K`      | Vim-style selection movement |
 | `Enter`        | Open file or directory       |
-| `Backspace`    | Go to parent directory       |
+| `Backspace` / `H` | Go to parent directory       |
 | `Home` / `End` | Jump to start/end of list    |
 | `Q` / `Escape` | Quit Termix                  |
 

--- a/UI/InputHandler.cs
+++ b/UI/InputHandler.cs
@@ -35,7 +35,7 @@ public class InputHandler(FileManager fileManager)
         switch (key)
         {
             case ConsoleKey.Enter: fileManager.OpenSelectedItem(); break;
-            case ConsoleKey.Backspace: fileManager.NavigateUp(); break;
+            case ConsoleKey.Backspace or ConsoleKey.H: fileManager.NavigateUp(); break;
             case ConsoleKey.A: fileManager.BeginAdd(); break;
             case ConsoleKey.R: fileManager.BeginRename(); break;
             case ConsoleKey.D: fileManager.BeginDelete(); break;


### PR DESCRIPTION
- Add H key as alternative to Backspace for navigating to parent directory
- Maintains consistency with existing J/K vim-style navigation pattern
- Update README documentation to reflect new H key functionality
- Improves user experience for vim users and keyboard navigation