### PR TITLE
fix: show names of functions

### DIFF
--- a/Services/CustomSyntaxHighlighter.cs
+++ b/Services/CustomSyntaxHighlighter.cs
@@ -162,12 +162,15 @@ public class CustomSyntaxHighlighter
                 if (groupName != null && theme.TokenStyles.TryGetValue(groupName, out var style))
                 {
                     var valueToStyle = match.Value;
+                    var hasTrailingParenthesis = groupName == "function" && valueToStyle.EndsWith('(');
 
-                    if (groupName == "function") valueToStyle = match.Groups[1].Value;
+                    if (hasTrailingParenthesis)
+                        valueToStyle = valueToStyle[..^1];
 
                     sb.Append($"[{style.ToMarkup()}]{valueToStyle.EscapeMarkup()}[/]");
 
-                    if (groupName == "function") sb.Append('(');
+                    if (hasTrailingParenthesis)
+                        sb.Append('(');
                 }
                 else
                 {


### PR DESCRIPTION
- Trim trailing ‘(’ from function tokens instead of using the wrong group index, so function names render correctly.