### PR TITLE
fix: replace tabs in preview

### DIFF
--- a/Services/FilePreviewService.cs
+++ b/Services/FilePreviewService.cs
@@ -8,6 +8,7 @@ public class FilePreviewService
 {
     private static readonly string[] SourceArray = [".jpg", ".jpeg", ".png", ".gif", ".bmp"];
     private readonly CustomSyntaxHighlighter _highlighter = new();
+    private const string TabReplacement = "    ";
 
     public IRenderable GetPreview(string? filePath, int verticalOffset, int horizontalOffset)
     {
@@ -36,7 +37,7 @@ public class FilePreviewService
             var visibleLines = allLines
                 .Skip(verticalOffset)
                 .Take(previewHeight)
-                .Select(line => line.Length > horizontalOffset ? line[horizontalOffset..] : "")
+                .Select(line => line.Length > horizontalOffset ? line[horizontalOffset..].Replace("\t", TabReplacement) : "")
                 .ToArray();
 
             IRenderable content;


### PR DESCRIPTION
The preview is messed up if the file being previewed has a tab character.  
This is probably a Spectre.Console issue, as noted in https://github.com/spectreconsole/spectre.console/issues/1608.  
The issue is still open (last comment was six months ago), so it’s unlikely to be fixed any time soon.

### Workaround
Replace each `\t` with four spaces before rendering to prevent this problem.