### PR TITLE
fix: ensure UTF-8 output for fixing icon rendering issue

### DIFF
--- a/UI/DoubleBufferedRenderer.cs
+++ b/UI/DoubleBufferedRenderer.cs
@@ -1,5 +1,6 @@
 using Spectre.Console;
 using Spectre.Console.Rendering;
+using System.Text;
 
 namespace termix.UI;
 
@@ -25,6 +26,12 @@ public class DoubleBufferedRenderer
         _console.Write(layout);
         var output = _writer.ToString();
         Console.SetCursorPosition(0, 0);
+
+        if (Console.OutputEncoding.CodePage != Encoding.UTF8.CodePage)
+        {
+            Console.OutputEncoding = new UTF8Encoding(false);
+        }
+
         Console.Write(output);
     }
 }


### PR DESCRIPTION
### Problem
Packaged runs (global tool) were writing the double-buffered output with the process' default code page, which may not be UTF‑8 on Windows. Nerd Font private-use glyphs then rendered as tofu/squares.

### Root Cause
`UI/DoubleBufferedRenderer.Render` wrote the buffer using `Console.Write(output)` without ensuring `Console.OutputEncoding` is `UTF‑8`. Running from source tended to inherit a UTF‑8 environment from the host terminal/editor, so it appeared fine.

### Fix
In `UI/DoubleBufferedRenderer.cs`, inside `Render(IRenderable layout)`, enforce `UTF‑8` before writing:
This change alone ensures packaged runs render Nerd Font icons correctly.

### Testing
- Verified on Windows 11 with PowerShell 7 in Windows Terminal:
    - From source: icons render correctly.
    - Global tool installed from local .nupkg: icons now render correctly after the fix.

### Closes
- Fixes #9 