### PR TITLE
Native aot compatibility

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,14 +12,17 @@ public static class Program
             AnsiConsole.Clear();
             var fileManager = new FileManager(useIcons);
             fileManager.Run();
+
+            AnsiConsole.Clear();
         }
         catch (Exception ex)
         {
-            AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks);
-        }
-        finally
-        {
-            AnsiConsole.Clear();
+            AnsiConsole.MarkupLine($"{ex.GetType().Name}: [red]{ex.Message}[/]");
+
+            if (!string.IsNullOrEmpty(ex.StackTrace))
+            {
+                AnsiConsole.WriteLine(ex.StackTrace);
+            }
         }
 
         return Task.CompletedTask;

--- a/termix.csproj
+++ b/termix.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>termix</ToolCommandName>
         <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/termix.csproj
+++ b/termix.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <IsAotCompatible>true</IsAotCompatible>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>termix</ToolCommandName>
         <PackageOutputPath>./nupkg</PackageOutputPath>


### PR DESCRIPTION
1. The project has only one AOT-incompatible part - `AnsiConsole.WriteException` (it is marked with the `RequiresDynamicCode` attribute). So I replaced it.
2. `AnsiConsole.Clear()` in the `finally` block clears the exception that was just printed in the `catch` block, so I moved it to the end of the `try` block to be able to see the exception.
3. Set `IsAotCompatible` to true to enable AOT analyzers and display warnings when AOT-incompatible code is added.
4. Treat all warnings as errors to fail the build when AOT-incompatible code is added.